### PR TITLE
Moves detailed music info to their own pages

### DIFF
--- a/src/pages/castells-music/index.astro
+++ b/src/pages/castells-music/index.astro
@@ -341,7 +341,7 @@ import { YouTube } from '@astro-community/astro-embed-youtube'
 					<li>
 						<a
 							href="/castells-music/extended library/tocs_tradicionals-entrada_a_placa.pdf"
-							>Entrada a Placa</a
+							>Toc d'Entrada a la Plaça</a
 						>
 					</li>
 					<li>

--- a/src/pages/castells-music/index.astro
+++ b/src/pages/castells-music/index.astro
@@ -49,10 +49,8 @@ import { YouTube } from '@astro-community/astro-embed-youtube'
 						<a href="#scale-and-notation">Scale and Notation</a>
 					</li>
 					<li>
-						<a href="#inana">Inana</a>
+						<a href="#library">Library</a>
 					</li>
-					<li><a href="#polca-dours">Polca d'ours</a></li>
-					<li><a href="#toc-de-castells">Toc de Castells</a></li>
 					<li><a href="#extended-library">Extended Library</a></li>
 				</ol>
 			</section>
@@ -170,75 +168,13 @@ import { YouTube } from '@astro-community/astro-embed-youtube'
 			</section>
 
 			<section>
-				<h2 id="inana">Inana</h2>
-
-				<p>
-					Inana is also known as "La Cosa Està Negra", or "Ailala" It is a good
-					and quite simple tune to learn first.
-				</p>
-
-				<YouTube id="94raEvtKGD0" title="GRALLA - La soca està negra" />
-				<YouTube
-					id="XJUl3c9k4TM"
-					title="Elàctrica Dharma - La Cosa Està Negra"
-				/>
-
-				<img
-					src="/castells-music/sheet music/Inana [solfege].svg"
-					alt="Sheet music for Inana"
-				/>
-
-				<p>
-					<a href="/castells-music/sheet music/Inana [solfege].pdf">pdf</a> |
-					<a href="/castells-music/sheet music/Inana [solfege, diagrams].pdf"
-						>pdf with finger diagrams</a
-					>
-				</p>
-
-				<h3>Practice tracks</h3>
-
-				<YouTube id="xysBBITZE8k" title="Inana - practice tracks for flabiol" />
-			</section>
-
-			<section>
-				<h2 id="polca-dours">Polca d'ours</h2>
-
-				<p>
-					Polca d'ours, known in the UK as "Bear Dance" is usually played at the
-					end of a castells performance, for a particular dance (see first
-					video). Normally you play it three times, starting slowly and getting
-					faster each time.
-				</p>
-
-				<YouTube id="OQk10808Fik" title="Gralles i tabals, la polca d'ours" />
-				<YouTube id="LjSqRJhF7i0" title="GRALLA - Polca d'Ours" />
-				<YouTube id="e2ah854BuM8" title="Polca d'Ours" />
-
-				<img
-					src="/castells-music/sheet music/Polca d'ours [solfege].svg"
-					alt="Sheet music for Polca d'ours"
-				/>
-
-				<p>
-					<a href="/castells-music/sheet music/Polca d'ours [solfege].pdf"
-						>pdf</a
-					>
-					|
-					<a
-						href="/castells-music/sheet music/Polca d'ours [solfege, diagrams].pdf"
-						>pdf with finger diagrams</a
-					>
-				</p>
-			</section>
-
-			<section>
 				<h2 id="library">Library</h2>
 				<p>These are the tunes we play in Edinburgh!</p>
 
 				<ul>
-					<li>Inana</li>
+					<li><a href="./music-library/inana/">Inana</a></li>
 
-					<li>Polca d'Ours</li>
+					<li><a href="./music-library/polca-d-ours/">Polca d'Ours</a></li>
 
 					<li>
 						<a href="./music-library/toc-de-castells/">Toc de Castells</a>

--- a/src/pages/castells-music/index.astro
+++ b/src/pages/castells-music/index.astro
@@ -232,102 +232,18 @@ import { YouTube } from '@astro-community/astro-embed-youtube'
 			</section>
 
 			<section>
-				<h2 id="toc-de-castells">Toc de castells</h2>
+				<h2 id="library">Library</h2>
+				<p>These are the tunes we play in Edinburgh!</p>
 
-				<YouTube id="AMCeEoOgSvc" title="Música i castells: Toc de Castells" />
-				<YouTube
-					id="-ZBLMyaZg44"
-					title="Castellers del Poble Sec - 3d7 - mòbil Mabel - Diada de Santa Eulàlia (11-II-24)"
-				/>
+				<ul>
+					<li>Inana</li>
 
-				<p>
-					The toc de castells is the tune to play during a castells performance.
-					Its main purpose is to communicate to those in the tower (who cannot
-					see) what stage the tower is in.
-				</p>
+					<li>Polca d'Ours</li>
 
-				<p>
-					Each colla can have their own interpretation of the tune, which is why
-					you will find different groups playing it slightly differently.
-					However the main theme is instantly recognisable. For now, in the
-					Edinburgh colla, we will adopt the arrangement used by the
-					<a href="https://castellersdelpoblesec.cat/"
-						>Castellers del Poble Sec</a
-					>.
-				</p>
-
-				<img
-					src="/castells-music/sheet music/Toc de castells (1st Gralla) [solfge]-1.svg"
-					alt="Sheet music for Toc de Castells"
-				/>
-
-				<img
-					src="/castells-music/sheet music/Toc de castells (1st Gralla) [solfge]-2.svg"
-					alt="Sheet music for Toc de Castells"
-				/>
-
-				<p>
-					<a
-						href="/castells-music/sheet music/Toc de castells (1st Gralla) [solfege].pdf"
-						>pdf</a
-					>
-					|
-					<a
-						href="/castells-music/sheet music/Toc de castells (1st Gralla) [solfege, diagrams].pdf"
-						>pdf with finger diagrams</a
-					>
-				</p>
-
-				<h3>Structure of the tune</h3>
-
-				<p>Here's how you would play the Toc alongside a castell.</p>
-				<ol>
 					<li>
-						No music while the pinya (base) of the tower is formed and the
-						segons climb.
+						<a href="./music-library/toc-de-castells/">Toc de Castells</a>
 					</li>
-					<li>
-						Begin playing the toc when the terços begin climbing up the doces.
-					</li>
-					<li>
-						Play the A section on loop until l'aleta, when the enxaneta is about
-						to reach the top of the tower.
-					</li>
-					<li>
-						Play the trill of l'aleta when the enxaneta is climbing onto the
-						final person. When they raise their hand in the air, play the high
-						sol'! This is markes the peak of the tower. The crowd goes wild.
-					</li>
-					<li>
-						Play through the aleta section. Usually there is lots of time
-						between notes - it is very up to interpretation. Keep an eye on the
-						band leader for timings. The end of l'aleta runs straight into the B
-						section.
-					</li>
-					<li>
-						Play the B section on loop while the tower dismantles. Note that the
-						B section is identical to the A section, it just starts in a
-						different place.
-					</li>
-					<li>
-						Play the sortida when the tower is nearly finished, and there are
-						only a few people to climb down to the floor.
-					</li>
-				</ol>
-
-				<h3>Practice tracks</h3>
-
-				<p>
-					I have produced backing tracks to help you practice at home! They are
-					made for a flaviol in G, and there are a few different versions
-					available. I recommend using YouTube's playback speed settings to slow
-					the video down if you are not confident with the tune yet.
-				</p>
-
-				<YouTube
-					id="pRJwNJN040U"
-					title="Toc de Castells - practice tracks for flabiol"
-				/>
+				</ul>
 			</section>
 
 			<section>
@@ -405,9 +321,7 @@ import { YouTube } from '@astro-community/astro-embed-youtube'
 						>
 					</li>
 					<li>
-						<a
-							href="/castells-music/extended library/blackadder.pdf"
-						>
+						<a href="/castells-music/extended library/blackadder.pdf">
 							L'escurçó negre</a
 						>
 					</li>

--- a/src/pages/castells-music/music-library/inana.astro
+++ b/src/pages/castells-music/music-library/inana.astro
@@ -16,7 +16,7 @@ import { YouTube } from '@astro-community/astro-embed-youtube'
 	</head>
 	<body>
 		<div class="column">
-			<a href="../../">← back</a>
+			<a href="../../#extended-library">← back</a>
 			<h1>Inana</h1>
 
 			<p>

--- a/src/pages/castells-music/music-library/inana.astro
+++ b/src/pages/castells-music/music-library/inana.astro
@@ -1,0 +1,47 @@
+---
+import '../../../styles/castellsMusic.css'
+
+import { YouTube } from '@astro-community/astro-embed-youtube'
+---
+
+<!doctype html>
+<html lang="en" dir="ltr">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="description" content="Astro description" />
+		<meta name="viewport" content="width=device-width" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Castells Music</title>
+	</head>
+	<body>
+		<div class="column">
+			<a href="../../">← back</a>
+			<h1>Inana</h1>
+
+			<p>
+				Inana is also known as "La Cosa Està Negra", or "Ailala" It is a good
+				and quite simple tune to learn first.
+			</p>
+
+			<YouTube id="94raEvtKGD0" title="GRALLA - La soca està negra" />
+			<YouTube id="XJUl3c9k4TM" title="Elàctrica Dharma - La Cosa Està Negra" />
+
+			<img
+				src="/castells-music/sheet music/Inana [solfege].svg"
+				alt="Sheet music for Inana"
+			/>
+
+			<p>
+				<a href="/castells-music/sheet music/Inana [solfege].pdf">pdf</a> |
+				<a href="/castells-music/sheet music/Inana [solfege, diagrams].pdf"
+					>pdf with finger diagrams</a
+				>
+			</p>
+
+			<h3>Practice tracks</h3>
+
+			<YouTube id="xysBBITZE8k" title="Inana - practice tracks for flabiol" />
+		</div>
+	</body>
+</html>

--- a/src/pages/castells-music/music-library/polca-d-ours.astro
+++ b/src/pages/castells-music/music-library/polca-d-ours.astro
@@ -1,0 +1,48 @@
+---
+import '../../../styles/castellsMusic.css'
+
+import { YouTube } from '@astro-community/astro-embed-youtube'
+---
+
+<!doctype html>
+<html lang="en" dir="ltr">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="description" content="Astro description" />
+		<meta name="viewport" content="width=device-width" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Castells Music</title>
+	</head>
+	<body>
+		<div class="column">
+			<a href="../../">← back</a>
+
+			<h1 id="polca-dours">Polca d'ours</h1>
+			<p>
+				Polca d'ours, known in the UK as "Bear Dance" is usually played at the
+				end of a castells performance, for a particular dance (see first video).
+				Normally you play it three times, starting slowly and getting faster
+				each time.
+			</p>
+
+			<YouTube id="OQk10808Fik" title="Gralles i tabals, la polca d'ours" />
+			<YouTube id="LjSqRJhF7i0" title="GRALLA - Polca d'Ours" />
+			<YouTube id="e2ah854BuM8" title="Polca d'Ours" />
+
+			<img
+				src="/castells-music/sheet music/Polca d'ours [solfege].svg"
+				alt="Sheet music for Polca d'ours"
+			/>
+
+			<p>
+				<a href="/castells-music/sheet music/Polca d'ours [solfege].pdf">pdf</a>
+				|
+				<a
+					href="/castells-music/sheet music/Polca d'ours [solfege, diagrams].pdf"
+					>pdf with finger diagrams</a
+				>
+			</p>
+		</div>
+	</body>
+</html>

--- a/src/pages/castells-music/music-library/polca-d-ours.astro
+++ b/src/pages/castells-music/music-library/polca-d-ours.astro
@@ -16,7 +16,7 @@ import { YouTube } from '@astro-community/astro-embed-youtube'
 	</head>
 	<body>
 		<div class="column">
-			<a href="../../">← back</a>
+			<a href="../../#extended-library">← back</a>
 
 			<h1 id="polca-dours">Polca d'ours</h1>
 			<p>

--- a/src/pages/castells-music/music-library/toc-de-castells.astro
+++ b/src/pages/castells-music/music-library/toc-de-castells.astro
@@ -16,7 +16,7 @@ import { YouTube } from '@astro-community/astro-embed-youtube'
 	</head>
 	<body>
 		<div class="column">
-			<a href="../../">← back</a>
+			<a href="../../#extended-library">← back</a>
 			<h1>Toc de castells</h1>
 
 			<YouTube id="AMCeEoOgSvc" title="Música i castells: Toc de Castells" />

--- a/src/pages/castells-music/music-library/toc-de-castells.astro
+++ b/src/pages/castells-music/music-library/toc-de-castells.astro
@@ -17,7 +17,7 @@ import { YouTube } from '@astro-community/astro-embed-youtube'
 	<body>
 		<div class="column">
 			<a href="../../">← back</a>
-			<h1 id="toc-de-castells">Toc de castells</h1>
+			<h1>Toc de castells</h1>
 
 			<YouTube id="AMCeEoOgSvc" title="Música i castells: Toc de Castells" />
 			<YouTube

--- a/src/pages/castells-music/music-library/toc-de-castells.astro
+++ b/src/pages/castells-music/music-library/toc-de-castells.astro
@@ -1,0 +1,117 @@
+---
+import '../../../styles/castellsMusic.css'
+
+import { YouTube } from '@astro-community/astro-embed-youtube'
+---
+
+<!doctype html>
+<html lang="en" dir="ltr">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="description" content="Astro description" />
+		<meta name="viewport" content="width=device-width" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Castells Music</title>
+	</head>
+	<body>
+		<div class="column">
+			<a href="../../">← back</a>
+			<h1 id="toc-de-castells">Toc de castells</h1>
+
+			<YouTube id="AMCeEoOgSvc" title="Música i castells: Toc de Castells" />
+			<YouTube
+				id="-ZBLMyaZg44"
+				title="Castellers del Poble Sec - 3d7 - mòbil Mabel - Diada de Santa Eulàlia (11-II-24)"
+			/>
+
+			<p>
+				The toc de castells is the tune to play during a castells performance.
+				Its main purpose is to communicate to those in the tower (who cannot
+				see) what stage the tower is in.
+			</p>
+
+			<p>
+				Each colla can have their own interpretation of the tune, which is why
+				you will find different groups playing it slightly differently. However
+				the main theme is instantly recognisable. For now, in the Edinburgh
+				colla, we will adopt the arrangement used by the
+				<a href="https://castellersdelpoblesec.cat/">Castellers del Poble Sec</a
+				>.
+			</p>
+
+			<img
+				src="/castells-music/sheet music/Toc de castells (1st Gralla) [solfge]-1.svg"
+				alt="Sheet music for Toc de Castells"
+			/>
+
+			<img
+				src="/castells-music/sheet music/Toc de castells (1st Gralla) [solfge]-2.svg"
+				alt="Sheet music for Toc de Castells"
+			/>
+
+			<p>
+				<a
+					href="/castells-music/sheet music/Toc de castells (1st Gralla) [solfege].pdf"
+					>pdf</a
+				>
+				|
+				<a
+					href="/castells-music/sheet music/Toc de castells (1st Gralla) [solfege, diagrams].pdf"
+					>pdf with finger diagrams</a
+				>
+			</p>
+
+			<h3>Structure of the tune</h3>
+
+			<p>Here's how you would play the Toc alongside a castell.</p>
+			<ol>
+				<li>
+					No music while the pinya (base) of the tower is formed and the segons
+					climb.
+				</li>
+				<li>
+					Begin playing the toc when the terços begin climbing up the doces.
+				</li>
+				<li>
+					Play the A section on loop until l'aleta, when the enxaneta is about
+					to reach the top of the tower.
+				</li>
+				<li>
+					Play the trill of l'aleta when the enxaneta is climbing onto the final
+					person. When they raise their hand in the air, play the high sol'!
+					This is markes the peak of the tower. The crowd goes wild.
+				</li>
+				<li>
+					Play through the aleta section. Usually there is lots of time between
+					notes - it is very up to interpretation. Keep an eye on the band
+					leader for timings. The end of l'aleta runs straight into the B
+					section.
+				</li>
+				<li>
+					Play the B section on loop while the tower dismantles. Note that the B
+					section is identical to the A section, it just starts in a different
+					place.
+				</li>
+				<li>
+					Play the sortida when the tower is nearly finished, and there are only
+					a few people to climb down to the floor.
+				</li>
+			</ol>
+
+			<h3>Practice tracks</h3>
+
+			<p>
+				I have produced backing tracks to help you practice at home! They are
+				made for a flaviol in G, and there are a few different versions
+				available. I recommend using YouTube's playback speed settings to slow
+				the video down if you are not confident with the tune yet.
+			</p>
+
+			<YouTube
+				id="pRJwNJN040U"
+				title="Toc de Castells - practice tracks for flabiol"
+			/>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
<img width="659" alt="image" src="https://github.com/user-attachments/assets/d082c4ff-52f5-47e6-8149-69288fba9da5" />
This PR concerns the castells music page. Where we used to have detailed information about each tune on the main page, we now just have a list of links to their own separate pages.