### PR TITLE
hide the edinburgh toc

### DIFF
--- a/src/pages/castells-music/index.astro
+++ b/src/pages/castells-music/index.astro
@@ -187,12 +187,6 @@ import { YouTube } from '@astro-community/astro-embed-youtube'
 					</li>
 
 					<li>
-						<a href="./music-library/toc-de-castells-edinburgh-version/"
-							>Toc dels Cardats (Toc de Castells, Edinburgh Version)</a
-						>
-					</li>
-
-					<li>
 						<a href="./music-library/joan-del-riu/">Joan del Riu</a>
 					</li>
 


### PR DESCRIPTION
keeps the edinburgh toc page hidde non the website - only accessible if you know the link